### PR TITLE
Fix for fetching all categories instead of post-specific categories

### DIFF
--- a/analytics-wordpress.php
+++ b/analytics-wordpress.php
@@ -820,7 +820,7 @@ class Segment_Analytics_WordPress {
 			if ( is_single() && ! is_attachment() ) {
 
 				if ( ! self::is_excluded_post_type() ) {
-					$categories = implode( ', ', wp_list_pluck( get_categories( get_the_ID() ), 'name' ) );
+					$categories = implode( ', ', wp_list_pluck( get_the_category( get_the_ID() ), 'name' ) );
 					$track = array(
 						'event'      => sprintf( __( 'Viewed %s', 'segment' ), ucfirst( get_post_type() ) ),
 						'properties' => array(


### PR DESCRIPTION
common refrain from customers:

>For blog posts, it seems that each blog post view simply sends all of the categories we have on the site as properties, instead of the specific category of the viewed post. Here's an example: http://screencast.com/t/MGULv0fhnnrX

Fix: [`get_categories`](http://codex.wordpress.org/Function_Reference/get_categories) -> [`get_the_category`](http://codex.wordpress.org/Function_Reference/get_the_category)

`get_categories` returns all blog categories that satisfy a given query, where as `get_the_category` returns each category *assigned to the post id passed* 

@JustinSainton mind sanity checking ? :)