### PR TITLE
Multiple 'track' events attached to action - only one fires.

### DIFF
--- a/analytics-wordpress.php
+++ b/analytics-wordpress.php
@@ -130,7 +130,7 @@ class Segment_Analytics {
 		// Set the proper `library` option so we know where the API calls come from.
 		$options['library'] = 'analytics-wordpress';
 
-		include_once( SEG_FILE_PATH . '/templates/track.php' );
+		include( SEG_FILE_PATH . '/templates/track.php' );
 	}
 
 	/**


### PR DESCRIPTION
Change include_once() to include() to output the tracking snipper for each track event that is attached to an action.

E.g. Attaching a track event to woocommerce_thankyou action makes Segment Analytics "Completed Order" track event never fire.